### PR TITLE
Fix repr of non-text items leaking into raw_text

### DIFF
--- a/src/parsers/docling_parser.py
+++ b/src/parsers/docling_parser.py
@@ -68,9 +68,34 @@ def _resolve_node_type(item: Any) -> str:
     return "paragraph"
 
 
-def _build_node_content(item: Any, node_type: str, preset: str = "docling_fast", language: str = "en") -> Dict[str, Any]:
+def _figure_caption(item: Any, doc: Any) -> str:
+    """Returns the caption text of a figure item when Docling exposes one, otherwise an empty string."""
+    if doc is None or not hasattr(item, "caption_text"):
+        return ""
+    try:
+        caption = item.caption_text(doc)
+    except Exception:
+        return ""
+    return caption.strip() if isinstance(caption, str) else ""
+
+
+def _resolve_raw_text(item: Any, node_type: str, doc: Any = None) -> str:
+    """
+    Resolves the textual content of a Docling item.
+
+    Items without a text attribute (for example PictureItem) must yield an empty string,
+    never their object repr. Figures fall back to their caption when one is available.
+    """
+    text = getattr(item, "text", None)
+    raw_text = text.strip() if isinstance(text, str) else ""
+    if not raw_text and node_type == "figure":
+        raw_text = _figure_caption(item, doc)
+    return raw_text
+
+
+def _build_node_content(item: Any, node_type: str, preset: str = "docling_fast", language: str = "en", doc: Any = None) -> Dict[str, Any]:
     """Builds node content payload dictionary, applying deep OCR diacritic restoration if docling_deep preset is selected."""
-    raw_text = getattr(item, "text", str(item)).strip()
+    raw_text = _resolve_raw_text(item, node_type, doc)
     if preset == "docling_deep" and language == "pl":
         raw_text = raw_text.replace("piqtku", "piątku").replace("granicq", "granicą")
 
@@ -129,7 +154,7 @@ class DoclingParser:
                 global_page_index=page_no,
                 temp_slice_index=page_no,
                 bounding_box=BoundingBox(x0=x0, y0=y0, x1=x1, y1=y1, angle=float(angle)),
-                content=_build_node_content(item, node_type, self.preset, self.language)
+                content=_build_node_content(item, node_type, self.preset, self.language, doc=doc)
             )
             nodes.append(dom_node)
             node_counter += 1

--- a/src/tests/test_docling_parser.py
+++ b/src/tests/test_docling_parser.py
@@ -1,0 +1,83 @@
+"""
+src/tests/test_docling_parser.py
+
+Unit tests for DoclingParser item-to-node content mapping.
+These run without Docling installed: they exercise the mapping helpers with stub items.
+"""
+
+import unittest
+from src.parsers.docling_parser import _build_node_content, _resolve_node_type, _resolve_raw_text
+
+
+class _StubTextItem:
+    label = "text"
+
+    def __init__(self, text):
+        self.text = text
+
+
+class _StubPictureItem:
+    """Mimics docling PictureItem: it has a label and provenance but no text attribute."""
+    label = "picture"
+
+    def __init__(self, caption=None, raise_on_caption=False):
+        self._caption = caption
+        self._raise = raise_on_caption
+
+    def caption_text(self, doc):
+        if self._raise:
+            raise RuntimeError("caption lookup failed")
+        return self._caption
+
+    def __str__(self):
+        return "self_ref='#/pictures/0' parent=RefItem(cref='#/body') label=<DocItemLabel.PICTURE: 'picture'>"
+
+    __repr__ = __str__
+
+
+class _StubItemWithoutCaptionApi:
+    label = "picture"
+
+    def __str__(self):
+        return "self_ref='#/pictures/1' parent=RefItem(cref='#/body')"
+
+
+class TestDoclingParserContent(unittest.TestCase):
+
+    def test_text_item_keeps_stripped_text(self):
+        content = _build_node_content(_StubTextItem("  Hello world  "), "paragraph")
+        self.assertEqual(content["raw_text"], "Hello world")
+
+    def test_item_without_text_attribute_does_not_leak_repr(self):
+        item = _StubPictureItem()
+        content = _build_node_content(item, _resolve_node_type(item))
+        self.assertEqual(content["raw_text"], "")
+        self.assertNotIn("self_ref", content["raw_text"])
+
+    def test_item_without_text_or_caption_api_yields_empty_string(self):
+        item = _StubItemWithoutCaptionApi()
+        self.assertEqual(_resolve_raw_text(item, "figure", doc=object()), "")
+
+    def test_figure_uses_caption_when_available(self):
+        item = _StubPictureItem(caption="  Figure 1. Bond yield curve  ")
+        content = _build_node_content(item, "figure", doc=object())
+        self.assertEqual(content["raw_text"], "Figure 1. Bond yield curve")
+
+    def test_figure_caption_requires_doc(self):
+        item = _StubPictureItem(caption="Figure 1. Bond yield curve")
+        self.assertEqual(_resolve_raw_text(item, "figure", doc=None), "")
+
+    def test_figure_caption_lookup_error_is_swallowed(self):
+        item = _StubPictureItem(raise_on_caption=True)
+        self.assertEqual(_resolve_raw_text(item, "figure", doc=object()), "")
+
+    def test_non_string_text_attribute_is_ignored(self):
+        item = _StubTextItem(None)
+        self.assertEqual(_resolve_raw_text(item, "paragraph"), "")
+
+    def test_picture_label_resolves_to_figure(self):
+        self.assertEqual(_resolve_node_type(_StubPictureItem()), "figure")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2

## Root cause

`_build_node_content` in `src/parsers/docling_parser.py` resolved a node's text with `getattr(item, "text", str(item))`. Docling's `PictureItem` has no `.text`, so its full pydantic repr (`self_ref='#/pictures/0' parent=RefItem(...) ...`) was written into `raw_text`. The committed `output/document_dom.json` shows this on 3 of its 12 nodes, and the evaluator scored that repr as clean text.

## Change

- `_resolve_raw_text` returns the stripped `.text` when it is a string, otherwise an empty string. Object reprs can no longer reach the DOM.
- Figure nodes fall back to the caption when Docling exposes `caption_text(doc)`. The lookup is guarded, so a missing method, a `None` doc, or an exception all degrade to an empty string.
- `_build_node_content` gains an optional `doc` argument; the call site in `_parse_with_docling` passes it. No other call sites exist.

## Tests

`src/tests/test_docling_parser.py` (8 tests) covers: text items keep their text, items without `.text` never leak a repr, figure caption used when available, caption requires `doc`, caption lookup errors are swallowed, non-string `.text` is ignored, and `picture` labels resolve to `figure`. Like the existing suite these use stub items and run without Docling.

```
python -m unittest discover -s src/tests -t .
Ran 27 tests ... OK
```

## Notes

- `output/document_dom.json` will contain empty or caption `raw_text` for the three picture nodes once the sample is regenerated; I left the committed artifact untouched.
- The repository has no LICENSE file yet. Under which license would you like contributions to be accepted?
