### PR TITLE
Resolve Docling section headings as heading nodes

### DIFF
--- a/src/parsers/docling_parser.py
+++ b/src/parsers/docling_parser.py
@@ -58,11 +58,28 @@ def _fallback_top_left_bbox(bbox: Any, page_height: float) -> Tuple[float, float
     return getattr(bbox, "l", 0.0), getattr(bbox, "t", 0.0), getattr(bbox, "r", 0.0), getattr(bbox, "b", 0.0)
 
 
+# Docling emits DocItemLabel values such as "section_header" and "page_header". Exact labels
+# are resolved first: a substring check would route "section_header" to header_footer (it
+# contains "header") before the heading check could run.
+_EXACT_LABEL_TYPES: Dict[str, str] = {
+    "title": "heading",
+    "section_header": "heading",
+    "page_header": "header_footer",
+    "page_footer": "header_footer",
+    "table": "table_grid",
+    "picture": "figure",
+}
+
+
 def _resolve_node_type(item: Any) -> str:
     """Resolves cernodata DOM primitive type from docling item label."""
-    label = getattr(item, "label", "").lower() if hasattr(item, "label") else ""
-    if "header" in label or "footer" in label: return "header_footer"
+    label = getattr(item, "label", "") or ""
+    label = str(getattr(label, "value", label)).lower()
+    exact = _EXACT_LABEL_TYPES.get(label)
+    if exact:
+        return exact
     if "title" in label or "heading" in label or "section" in label: return "heading"
+    if "header" in label or "footer" in label: return "header_footer"
     if "table" in label: return "table_grid"
     if "picture" in label or "figure" in label: return "figure"
     return "paragraph"

--- a/src/tests/test_docling_node_types.py
+++ b/src/tests/test_docling_node_types.py
@@ -1,0 +1,62 @@
+"""
+src/tests/test_docling_node_types.py
+
+Unit tests for mapping Docling item labels to DocumentDOM node types.
+These run without Docling installed: they exercise the resolver with stub items.
+"""
+
+import unittest
+from enum import Enum
+from src.parsers.docling_parser import _resolve_node_type
+
+
+class _StubItem:
+    def __init__(self, label):
+        self.label = label
+
+
+class _StubLabel(str, Enum):
+    """Mimics docling_core DocItemLabel, a str-backed Enum."""
+    SECTION_HEADER = "section_header"
+    PAGE_HEADER = "page_header"
+
+
+class TestResolveNodeType(unittest.TestCase):
+
+    def test_section_header_is_heading(self):
+        self.assertEqual(_resolve_node_type(_StubItem("section_header")), "heading")
+
+    def test_title_is_heading(self):
+        self.assertEqual(_resolve_node_type(_StubItem("title")), "heading")
+
+    def test_page_header_and_footer_are_header_footer(self):
+        self.assertEqual(_resolve_node_type(_StubItem("page_header")), "header_footer")
+        self.assertEqual(_resolve_node_type(_StubItem("page_footer")), "header_footer")
+
+    def test_table_is_table_grid(self):
+        self.assertEqual(_resolve_node_type(_StubItem("table")), "table_grid")
+
+    def test_picture_is_figure(self):
+        self.assertEqual(_resolve_node_type(_StubItem("picture")), "figure")
+
+    def test_body_text_labels_are_paragraph(self):
+        for label in ("text", "paragraph", "list_item", "caption", "footnote"):
+            self.assertEqual(_resolve_node_type(_StubItem(label)), "paragraph", label)
+
+    def test_enum_labels_resolve_by_value(self):
+        self.assertEqual(_resolve_node_type(_StubItem(_StubLabel.SECTION_HEADER)), "heading")
+        self.assertEqual(_resolve_node_type(_StubItem(_StubLabel.PAGE_HEADER)), "header_footer")
+
+    def test_label_case_is_ignored(self):
+        self.assertEqual(_resolve_node_type(_StubItem("Section_Header")), "heading")
+
+    def test_unknown_heading_like_label_falls_back_to_heading(self):
+        self.assertEqual(_resolve_node_type(_StubItem("field_heading")), "heading")
+
+    def test_missing_label_is_paragraph(self):
+        self.assertEqual(_resolve_node_type(object()), "paragraph")
+        self.assertEqual(_resolve_node_type(_StubItem(None)), "paragraph")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #4

## Root cause

`_resolve_node_type` in `src/parsers/docling_parser.py` mapped labels by substring and tested `"header" in label` before the heading check. Docling's `DocItemLabel.SECTION_HEADER` has the value `"section_header"`, so every section heading was classified as `header_footer`. The committed `output/document_dom.json` shows this: the document headline (`node_p1_n4`) is typed `header_footer`, and the sample has no `heading` node at all.

## Change

- Add `_EXACT_LABEL_TYPES`, resolving Docling's exact label values first: `title` and `section_header` to `heading`; `page_header` and `page_footer` to `header_footer`; `table` to `table_grid`; `picture` to `figure`.
- Keep the substring checks as a fallback for labels not in the map, with the heading check moved ahead of the header/footer check so the same misrouting cannot recur for a future label.
- Read enum labels by `.value` before lowercasing. `DocItemLabel` is a `str` Enum, and `str()` of such a member returns `"DocItemLabel.SECTION_HEADER"` on Python 3.11+, which would have broken the substring fallback there.

Behaviour for all other labels (`text`, `list_item`, `caption`, `footnote`, unknown) is unchanged: they still resolve to `paragraph`.

## Tests

`src/tests/test_docling_node_types.py` (10 tests): section_header and title resolve to heading, page_header and page_footer to header_footer, table and picture to their types, body-text labels to paragraph, str-Enum labels resolve by value, label case is ignored, an unknown heading-like label falls back to heading, and a missing or `None` label is paragraph. Like the existing suite these use stub items and run without Docling.

```
python -m unittest discover -s src/tests -t .
Ran 29 tests ... OK
```

## Notes

- Independent of #3; both branch from `main` and touch different functions and different test files, so they merge in either order.
- Docling also emits `chart`, which currently falls through to `paragraph`. Mapping it to `figure` is probably right but I left it out to keep this change to the reported bug.
- `output/document_dom.json` will show `node_p1_n4` as `heading` once the sample is regenerated; I left the committed artifact untouched.
